### PR TITLE
fix: migrate to @signinwithethereum/siwe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ src/
 - **viem** (v2.0+): Ethereum interactions, wallet clients, public clients
 - **permissionless** (v0.2.38+): ERC-4337 account abstraction (Safe deployment)
 - **@rhinestone/module-sdk** (v0.2.10+): Session key management for Safe
-- **siwe**: Sign-In with Ethereum authentication
+- **@signinwithethereum/siwe**: Sign-In with Ethereum authentication
 - **axios**: HTTP client for both API backends
 
 ### Supported Chains

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@zyfai/sdk",
-  "version": "0.2.26",
+  "version": "0.2.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zyfai/sdk",
-      "version": "0.2.26",
+      "version": "0.2.31",
       "license": "MIT",
       "dependencies": {
         "@rhinestone/module-sdk": "^0.2.10",
+        "@signinwithethereum/siwe": "^4.1.0",
         "axios": "^1.6.0",
-        "permissionless": "^0.2.38",
-        "siwe": "^3.0.0"
+        "permissionless": "^0.2.38"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -33,6 +33,13 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -529,13 +536,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -905,6 +941,45 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
@@ -954,46 +1029,36 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@spruceid/siwe-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-3.0.0.tgz",
-      "integrity": "sha512-Y92k63ilw/8jH9Ry4G2e7lQd0jZAvb0d/Q7ssSD0D9mp/Zt2aCXIc3g0ny9yhplpAx1QXHsMz/JJptHK/zDGdw==",
+    "node_modules/@signinwithethereum/siwe": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe/-/siwe-4.1.0.tgz",
+      "integrity": "sha512-NT56M82i+A2uBU++F9PSBvEYPcjUV3BdClRVojWt3cbe7WizIVH1wi2qKJJR570RLHZvr8q1gUf0E90WymlMeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/hashes": "^1.1.2",
+        "@signinwithethereum/siwe-parser": "^4.1.0"
+      },
+      "peerDependencies": {
+        "ethers": "^5.7.0 || ^6.13.0",
+        "viem": "^2.7.0"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@signinwithethereum/siwe-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@signinwithethereum/siwe-parser/-/siwe-parser-4.1.0.tgz",
+      "integrity": "sha512-aS+bU5QpTQgMpC6HjQHuKJpltUrkyGUVNuhuBLARa39wF1B+m05/4bgnf2qrEcgQONfU36A2Nbn3ibmwhHkc2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.7.0",
         "apg-js": "^4.4.0"
       }
-    },
-    "node_modules/@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/int": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1028,6 +1093,28 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1344,6 +1431,13 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1520,6 +1614,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/joycon": {
@@ -1700,6 +1810,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.13",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.13.tgz",
+      "integrity": "sha512-N3slDyEUq3qGw/53Xd8YZPZD7NUbbiOJDeWKvQ1ElNo2mFjjz6cV2TIbGenHw7k5ATcefDQh42dwUWoGtxU9Hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/pathe": {
@@ -1892,19 +2033,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/siwe": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-3.0.0.tgz",
-      "integrity": "sha512-P2/ry7dHYJA6JJ5+veS//Gn2XDwNb3JMvuD6xiXX8L/PJ1SNVD4a3a8xqEbmANx+7kNQcD8YAh1B9bNKKvRy/g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@spruceid/siwe-parser": "^3.0.0",
-        "@stablelib/random": "^1.0.1"
-      },
-      "peerDependencies": {
-        "ethers": "^5.6.8 || ^6.0.8"
       }
     },
     "node_modules/solady": {
@@ -2110,7 +2238,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2140,6 +2268,59 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.47.11",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.11.tgz",
+      "integrity": "sha512-UbEKBW11wKI+TkGMl3ONPvFYN2tV0Srhtm6Bbvct/cirhBRNfv0hB3S1Pnn/zIl+U0RvNEm+yRXEOQVIr8rK+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.13",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@rhinestone/module-sdk": "^0.2.10",
     "axios": "^1.6.0",
     "permissionless": "^0.2.38",
-    "siwe": "^3.0.0"
+    "@signinwithethereum/siwe": "^4.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/core/ZyfaiSDK.ts
+++ b/src/core/ZyfaiSDK.ts
@@ -92,7 +92,7 @@ import {
   convertAssetInternally,
   removeUnusedFields,
 } from "../utils/strategy";
-import { SiweMessage } from "siwe";
+import { SiweMessage } from "@signinwithethereum/siwe";
 
 export class ZyfaiSDK {
   private httpClient: HttpClient;


### PR DESCRIPTION
# fix: migrate from `siwe` to `@signinwithethereum/siwe`

Migrates the SDK from the old Spruce `siwe` package (v3.0.0) to `@signinwithethereum/siwe` (Ethereum Identity Foundation, v4.1.0).

The Spruce [siwe](https://github.com/spruceid/siwe) package is no longer actively maintained. 

Stewardship of the SIWE standard has [moved to the Ethereum Identity Foundation](https://x.com/BrantlyMillegan/status/1956389297461899533) ([GitHub](https://github.com/signinwithethereum)). [`@signinwithethereum/siwe`](https://www.npmjs.com/package/@signinwithethereum/siwe) is the official successor TypeScript implementation. 

The new package:

- Supports **viem natively** as a peer dependency (alongside optional ethers)
- Has first-class **EIP-1271** and **EIP-6492** smart wallet verification
- Maintains the same `SiweMessage` API -- constructor and `prepareMessage()` are identical
- **Drops the transitive `ethers` peer dependency** -- the old package required `ethers`, the new one makes both `viem` and `ethers` optional. Since the SDK already uses `viem`, consumers no longer need `ethers` installed.

## Changes

| File | Change |
|------|--------|
| `package.json` | `"siwe": "^3.0.0"` -> `"@signinwithethereum/siwe": "^4.1.0"` |
| `src/core/ZyfaiSDK.ts` | Updated import: `from "siwe"` -> `from "@signinwithethereum/siwe"` |
| `CLAUDE.md` | Updated dependency reference to new package name |
| `package-lock.json` | Dependency tree updated (removes `siwe`, `@spruceid/siwe-parser`, `@stablelib/*`; adds `@signinwithethereum/siwe`, `@signinwithethereum/siwe-parser`; resolves `viem` peer deps) |

## Impact

The SDK only uses two things from the SIWE package:

1. `new SiweMessage({...})` -- construct a message object
2. `.prepareMessage()` -- serialize to the EIP-4361 string for wallet signing

Both are identical between v3 and v4. The SDK does **not** call `.verify()` (verification happens server-side) and does **not** use `generateNonce()` (nonce comes from the backend API). No functional code changes are needed.

## Build

```
npm run build

CLI Building entry: src/index.ts
ESM dist/index.mjs 117.63 KB  -- Build success
CJS dist/index.js 119.92 KB   -- Build success
DTS dist/index.d.ts 49.21 KB  -- Build success
```

## Note on `pnpm-lock.yaml`

`pnpm-lock.yaml` still references the old `siwe@3.0.0`. Not modified here -- it's been stale since the first commit and the project uses npm. Should be regenerated or removed separately.

## Reference migration

- [x402-foundation/x402#1917](https://github.com/x402-foundation/x402/pull/1917) -- same migration
